### PR TITLE
修复设置保存覆盖、Bark 地址清空及失效查询会话恢复

### DIFF
--- a/src-tauri/src/chromium_fetcher.rs
+++ b/src-tauri/src/chromium_fetcher.rs
@@ -475,11 +475,23 @@ impl AppleChromiumFetcher {
         if guard.is_none() {
             *guard = Some(ChromiumSession::start().await?);
         }
-        let payload = guard
+        let fetched = guard
             .as_mut()
             .expect("刚初始化的 Chromium 会话应当存在")
             .fetch(region, store_number, parts)
-            .await?;
+            .await;
+        let payload = match fetched {
+            Ok(payload) => payload,
+            Err(error) => {
+                // CDP 断连、命令超时或页面执行失败后，不再缓存这个失效会话。
+                // 保留原错误交给引擎处理，后续查询才重建，不在失败请求内重试。
+                // Apple 的 HTTP 限流和库存数据仍走下面原有的分类逻辑。
+                if matches!(error, ApiError::Transport(_)) {
+                    *guard = None;
+                }
+                return Err(error);
+            }
+        };
 
         match payload.status {
             200 => {
@@ -524,6 +536,91 @@ impl Fetcher for AppleChromiumFetcher {
 mod tests {
     use super::*;
     use apw_core::model::region_by_locale;
+
+    /// 模拟浏览器的 CDP 边界，不启动 Chromium，也不访问 Apple。
+    async fn cdp_fixture(response: Value) -> (AppleChromiumFetcher, tokio::task::JoinHandle<bool>) {
+        let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let address = listener.local_addr().unwrap();
+        let peer = tokio::spawn(async move {
+            let (stream, _) = listener.accept().await.unwrap();
+            let mut socket = tokio_tungstenite::accept_async(stream).await.unwrap();
+            let request = socket.next().await.unwrap().unwrap();
+            let request: Value = serde_json::from_str(request.to_text().unwrap()).unwrap();
+            let mut response = response;
+            response["id"] = request["id"].clone();
+            socket
+                .send(Message::Text(response.to_string().into()))
+                .await
+                .unwrap();
+            // 观察浏览器一端的连接生命周期，不依赖查询器内部的 Option 状态。
+            matches!(
+                tokio::time::timeout(Duration::from_millis(500), socket.next()).await,
+                Ok(None) | Ok(Some(Err(_))) | Ok(Some(Ok(Message::Close(_))))
+            )
+        });
+        let (socket, _) = connect_async(format!("ws://{address}")).await.unwrap();
+        let session = ChromiumSession {
+            child: Command::new("rustc")
+                .arg("--version")
+                .stdout(Stdio::null())
+                .spawn()
+                .unwrap(),
+            _profile: tempfile::tempdir().unwrap(),
+            socket,
+            next_command_id: 1,
+            locale: Some("zh_CN"),
+            last_inventory_request: None,
+        };
+        (
+            AppleChromiumFetcher {
+                session: Arc::new(Mutex::new(Some(session))),
+            },
+            peer,
+        )
+    }
+
+    #[tokio::test]
+    async fn 浏览器会话错误后释放失效连接供下轮重建() {
+        let (fetcher, peer) = cdp_fixture(json!({
+            "error": {"code": -32000, "message": "Target closed"}
+        }))
+        .await;
+        let result = fetcher
+            .pickup_message(
+                region_by_locale("zh_CN").unwrap(),
+                "R390",
+                &["MG6X4CH/A".to_string()],
+            )
+            .await;
+        assert!(matches!(result, Err(ApiError::Transport(_))));
+        assert!(
+            peer.await.unwrap(),
+            "失效 CDP 连接仍被缓存，下轮会继续使用坏会话"
+        );
+    }
+
+    #[tokio::test]
+    async fn 限流保留会话而明确拦截仍清理会话() {
+        for (status, should_close) in [(429, false), (403, true), (541, true)] {
+            let (fetcher, peer) = cdp_fixture(json!({
+                "result": {"result": {"value": {"status": status, "body": "{}"}}}
+            }))
+            .await;
+            let result = fetcher
+                .pickup_message(
+                    region_by_locale("zh_CN").unwrap(),
+                    "R390",
+                    &["MG6X4CH/A".to_string()],
+                )
+                .await;
+            if status == 429 {
+                assert!(matches!(result, Err(ApiError::RateLimited(_))));
+            } else {
+                assert!(matches!(result, Err(ApiError::Blocked(_))));
+            }
+            assert_eq!(peer.await.unwrap(), should_close, "HTTP {status}");
+        }
+    }
 
     #[test]
     fn 能找到本机chromium浏览器() {

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -140,10 +140,10 @@ export default function App() {
   const [storeNumbers, setStoreNumbers] = useState<string[]>([]);
   const [partNumbers, setPartNumbers] = useState<string[]>([]);
   const [isAdding, setIsAdding] = useState(false);
-  const [barkDraft, setBarkDraft] = useState("");
+  const [barkDraft, setBarkDraft] = useState<string | null>(null);
   const [intervalDraft, setIntervalDraft] = useState<number | null>(null);
 
-  const barkValue = barkDraft || ui.settings.barkUrl;
+  const barkValue = barkDraft ?? ui.settings.barkUrl;
   const intervalValue = intervalDraft ?? ui.settings.intervalSeconds;
   const latestCheckedMs = Math.max(0, ...ui.rows.map((row) => row.lastCheckedMs ?? 0));
   const secondsUntilNextCheck = latestCheckedMs
@@ -623,8 +623,8 @@ export default function App() {
                     value={barkValue}
                     onChange={(event) => setBarkDraft(event.target.value)}
                     onBlur={() => {
-                      setBarkDraft("");
-                      void saveSettings({ ...ui.settings, barkUrl: barkValue.trim() });
+                      setBarkDraft(null);
+                      void saveSettings({ barkUrl: barkValue.trim() });
                     }}
                   />
                 </div>
@@ -636,7 +636,7 @@ export default function App() {
                       id="sound"
                       aria-label="提示音"
                       checked={ui.settings.soundEnabled}
-                      onCheckedChange={(value) => void saveSettings({ ...ui.settings, soundEnabled: value })}
+                      onCheckedChange={(value) => void saveSettings({ soundEnabled: value })}
                     />
                   </div>
                   <div className="setting-row">
@@ -645,7 +645,7 @@ export default function App() {
                       id="openbag"
                       aria-label="有货时自动打开购物袋"
                       checked={ui.settings.openBagOnHit}
-                      onCheckedChange={(value) => void saveSettings({ ...ui.settings, openBagOnHit: value })}
+                      onCheckedChange={(value) => void saveSettings({ openBagOnHit: value })}
                     />
                   </div>
                 </div>

--- a/src/lib/store.ts
+++ b/src/lib/store.ts
@@ -252,13 +252,26 @@ export async function loadCatalog(locale: string): Promise<void> {
   }
 }
 
-export async function saveSettings(next: Settings): Promise<void> {
-  try {
-    const saved = await invoke<Settings>("save_settings", { settings: next });
-    update({ settings: saved });
-  } catch (err) {
-    pushLog(`保存设置失败：${String(err)}`);
-  }
+// 所有修改设置的命令按顺序执行，查询间隔和目标列表也不能被旧设置覆盖。
+let settingsWrite: Promise<unknown> = Promise.resolve();
+
+function enqueueSettingsWrite<T>(operation: () => Promise<T>): Promise<T> {
+  const next = settingsWrite.then(operation);
+  settingsWrite = next.catch(() => undefined);
+  return next;
+}
+
+export function saveSettings(patch: Partial<Settings>): Promise<void> {
+  return enqueueSettingsWrite(async () => {
+    try {
+      const saved = await invoke<Settings>("save_settings", {
+        settings: { ...state.settings, ...patch },
+      });
+      update({ settings: saved });
+    } catch (err) {
+      pushLog(`保存设置失败：${String(err)}`);
+    }
+  });
 }
 
 export function setCategory(category: Category): void {
@@ -266,19 +279,21 @@ export function setCategory(category: Category): void {
 }
 
 export async function changeLocale(locale: string): Promise<void> {
-  await saveSettings({ ...state.settings, locale });
+  await saveSettings({ locale });
   await loadCatalog(locale);
 }
 
 export async function setTargets(targets: Target[]): Promise<boolean> {
-  try {
-    const rows = await invoke<TargetState[]>("set_targets", { targets });
-    update({ rows, settings: { ...state.settings, targets } });
-    return true;
-  } catch (err) {
-    pushLog(`更新监控列表失败：${String(err)}`);
-    return false;
-  }
+  return enqueueSettingsWrite(async () => {
+    try {
+      const rows = await invoke<TargetState[]>("set_targets", { targets });
+      update({ rows, settings: { ...state.settings, targets } });
+      return true;
+    } catch (err) {
+      pushLog(`更新监控列表失败：${String(err)}`);
+      return false;
+    }
+  });
 }
 
 export async function startWatching(): Promise<void> {
@@ -308,12 +323,14 @@ export async function stopWatching(): Promise<void> {
 }
 
 export async function setIntervalSeconds(seconds: number): Promise<void> {
-  try {
-    const applied = await invoke<number>("set_interval", { seconds });
-    update({ settings: { ...state.settings, intervalSeconds: applied } });
-  } catch (err) {
-    pushLog(`设置查询间隔失败：${String(err)}`);
-  }
+  return enqueueSettingsWrite(async () => {
+    try {
+      const applied = await invoke<number>("set_interval", { seconds });
+      update({ settings: { ...state.settings, intervalSeconds: applied } });
+    } catch (err) {
+      pushLog(`设置查询间隔失败：${String(err)}`);
+    }
+  });
 }
 
 /**
@@ -348,6 +365,7 @@ export async function refreshProducts(): Promise<void> {
 
 export async function testNotify(): Promise<void> {
   try {
+    await settingsWrite;
     await invoke("test_notify");
     pushLog("已发出测试提醒。");
   } catch (err) {

--- a/tests/store-settings.test.mjs
+++ b/tests/store-settings.test.mjs
@@ -1,0 +1,109 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { registerHooks } from "node:module";
+
+// Exercise the real store with a controllable IPC boundary, without a desktop app.
+let invoke;
+globalThis.__settingsTestInvoke = (...args) => invoke(...args);
+registerHooks({
+  resolve(specifier, context, nextResolve) {
+    const stubs = {
+      "@tauri-apps/api/core": "export const invoke = (...args) => globalThis.__settingsTestInvoke(...args);",
+      "@tauri-apps/api/event": "export const listen = async () => () => {};",
+      "@tauri-apps/plugin-opener": "export const openUrl = async () => {};",
+    };
+    if (specifier in stubs) {
+      return { url: `data:text/javascript,${encodeURIComponent(stubs[specifier])}`, shortCircuit: true };
+    }
+    if (specifier.startsWith("./") && !specifier.endsWith(".ts") && context.parentURL?.includes("/src/lib/")) {
+      return nextResolve(`${specifier}.ts`, context);
+    }
+    return nextResolve(specifier, context);
+  },
+});
+
+const defaults = {
+  locale: "zh_CN", targets: [], intervalSeconds: 30,
+  barkUrl: "https://example.invalid/old", soundEnabled: true, openBagOnHit: true,
+};
+let generation = 0;
+async function setup() {
+  const store = await import(`../src/lib/store.ts?case=${++generation}`);
+  let persisted = { ...defaults };
+  let release;
+  let blockNext = false;
+  const calls = [];
+  invoke = async (command, args) => {
+    calls.push(command);
+    if (blockNext) {
+      blockNext = false;
+      await new Promise((resolve) => { release = resolve; });
+    }
+    if (command === "save_settings") persisted = { ...args.settings };
+    if (command === "set_interval") persisted.intervalSeconds = Math.max(5, args.seconds);
+    if (command === "set_targets") persisted.targets = args.targets;
+    if (command === "set_targets") return [];
+    if (command === "set_interval") return persisted.intervalSeconds;
+    return { ...persisted };
+  };
+  await store.saveSettings(defaults);
+  calls.length = 0;
+  return {
+    store, calls, persisted: () => persisted,
+    block: () => { blockNext = true; },
+    release: () => release(),
+  };
+}
+const tick = () => new Promise((resolve) => setImmediate(resolve));
+
+test("overlapping edits merge with the last saved settings", async () => {
+  const ctx = await setup();
+  ctx.block();
+  const first = ctx.store.saveSettings({ barkUrl: "" });
+  await tick();
+  const second = ctx.store.saveSettings({ soundEnabled: false });
+  await tick();
+  assert.deepEqual(ctx.calls, ["save_settings"]);
+  ctx.release();
+  await Promise.all([first, second]);
+  assert.deepEqual(ctx.persisted(), { ...defaults, barkUrl: "", soundEnabled: false });
+});
+
+test("interval and target commands cannot be overwritten by queued settings", async () => {
+  const ctx = await setup();
+  ctx.block();
+  const interval = ctx.store.setIntervalSeconds(15);
+  await tick();
+  const targets = [{ locale: "zh_CN", storeNumber: "R390", storeTitle: "Test", partNumber: "TEST/A", productName: "Test" }];
+  const updated = ctx.store.setTargets(targets);
+  const saved = ctx.store.saveSettings({ soundEnabled: false });
+  await tick();
+  assert.deepEqual(ctx.calls, ["set_interval"]);
+  ctx.release();
+  await Promise.all([interval, updated, saved]);
+  assert.deepEqual(ctx.persisted(), { ...defaults, intervalSeconds: 15, targets, soundEnabled: false });
+});
+
+test("test notification waits for the cleared Bark address to finish saving", async () => {
+  const ctx = await setup();
+  ctx.block();
+  const save = ctx.store.saveSettings({ barkUrl: "" });
+  await tick();
+  const notification = ctx.store.testNotify();
+  await tick();
+  assert.deepEqual(ctx.calls, ["save_settings"]);
+  ctx.release();
+  await Promise.all([save, notification]);
+  assert.deepEqual(ctx.calls, ["save_settings", "test_notify"]);
+  assert.equal(ctx.persisted().barkUrl, "");
+});
+
+test("a failed write does not prevent subsequent edits", async () => {
+  const ctx = await setup();
+  const originalInvoke = invoke;
+  invoke = async () => { throw new Error("disk unavailable"); };
+  await ctx.store.saveSettings({ soundEnabled: false });
+  invoke = originalInvoke;
+  await ctx.store.saveSettings({ barkUrl: "" });
+  assert.deepEqual(ctx.persisted(), { ...defaults, barkUrl: "" });
+});


### PR DESCRIPTION
清空已保存的 Bark 地址时，输入框会把空字符串当成“未编辑”，回填旧地址；快速修改多个设置时，后一次提交的旧快照也可能覆盖先前修改。另外，CDP 断连或页面执行失败后，查询器仍会缓存失效会话，后续查询继续使用同一连接。

本次修复：

- 用 `null` 表示尚未编辑的 Bark 草稿，允许保存空地址。
- 设置以局部修改提交，并与查询间隔、监控目标的修改共用保存队列；实际执行时合并最新设置。测试提醒等待已排队的保存完成。
- 浏览器传输错误后释放失效会话，由后续查询重新建立；保持 HTTP 429 的限流处理及 403/541 的既有分类，不在失败请求内部重试。

验证：

- `pnpm test`：13 项通过。新增测试以可控 IPC 延迟覆盖连续修改、间隔/目标与设置交错、清空地址后立刻测试，以及保存失败后继续编辑；前三种时序在原实现中能复现失败。
- `pnpm build`、`cargo fmt --all --check`、`cargo clippy --all-targets --all-features -- -D warnings` 通过。
- `cargo test --workspace`：186 项通过，6 项现场/网络诊断测试保持忽略。新增本地 WebSocket 对照测试确认错误后连接释放，以及 429 保留会话、403/541 清理会话。
- 本地 macOS 手工验证过 Bark 地址清空；终止应用专用查询浏览器后，后续轮次能恢复真实库存查询。没有改变库存判定和每轮提醒策略。
